### PR TITLE
Fix urls import for Django 1.6

### DIFF
--- a/loginas/urls.py
+++ b/loginas/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('loginas.views',
     url(r"^login/user/(?P<user_id>.+)/$", "user_login", name="loginas-user-login"),


### PR DESCRIPTION
Django 1.6 removed the old `django.conf.urls.defaults` module.

This makes loginas work with the Django 1.6 beta.
