### PR TITLE
Always use model backend to login

### DIFF
--- a/loginas/views.py
+++ b/loginas/views.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
-from django.contrib.auth import load_backend, login
+from django.contrib.auth import login
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import redirect
 from django.utils.importlib import import_module
@@ -50,12 +50,9 @@ def user_login(request, user_id):
         messages.error(request, "You do not have permission to do that.")
         return redirect(request.META.get("HTTP_REFERER", "/"))
 
-    # Find a suitable backend.
-    if not hasattr(user, 'backend'):
-        for backend in settings.AUTHENTICATION_BACKENDS:
-            if user == load_backend(backend).get_user(user.pk):
-                user.backend = backend
-                break
+    # attach the modal backend 
+    if not hasattr(user, 'backend'):    
+        user.backend = 'django.contrib.auth.backends.ModelBackend'
 
     # Log the user in.
     if hasattr(user, 'backend'):


### PR DESCRIPTION
Why would you want to use anything else?

This makes sure that loginas works all the time. Was having trouble using it with the backend in python-social-auth.
