### PR TITLE
Ability to set tags on messages and a minor compatibility fix

### DIFF
--- a/loginas/settings.py
+++ b/loginas/settings.py
@@ -17,6 +17,8 @@ MESSAGE_LOGIN_SWITCH = getattr(
 
 MESSAGE_LOGIN_REVERT = getattr(
     settings,
-    "MESSAGE_LOGIN_REVERT",
+    "LOGINAS_MESSAGE_LOGIN_REVERT",
     _("You are now logged back in as {username}")
 )
+
+MESSAGE_EXTRA_TAGS = getattr(settings, 'LOGINAS_MESSAGE_EXTRA_TAGS', '')

--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -37,7 +37,8 @@ def login_as(user, request, store_original_user=True):
 
     # Set a flag on the session
     if store_original_user:
-        messages.warning(request, la_settings.MESSAGE_LOGIN_SWITCH.format(username=user.__dict__[username_field]))
+        messages.warning(request, la_settings.MESSAGE_LOGIN_SWITCH.format(username=user.__dict__[username_field]),
+                         extra_tags=la_settings.MESSAGE_EXTRA_TAGS)
         request.session[la_settings.USER_SESSION_FLAG] = signer.sign(original_user_pk)
 
 
@@ -54,10 +55,11 @@ def restore_original_login(request):
     try:
         original_user_pk = signer.unsign(
             original_session,
-            max_age=timedelta(days=la_settings.USER_SESSION_DAYS_TIMESTAMP)
+            max_age=timedelta(days=la_settings.USER_SESSION_DAYS_TIMESTAMP).total_seconds()
         )
         user = get_user_model().objects.get(pk=original_user_pk)
-        messages.info(request, la_settings.MESSAGE_LOGIN_REVERT.format(username=user.__dict__[username_field]))
+        messages.info(request, la_settings.MESSAGE_LOGIN_REVERT.format(username=user.__dict__[username_field]),
+                      extra_tags=la_settings.MESSAGE_EXTRA_TAGS)
         login_as(user, request, store_original_user=False)
         if la_settings.USER_SESSION_FLAG in request.session:
             del request.session[la_settings.USER_SESSION_FLAG]

--- a/loginas/views.py
+++ b/loginas/views.py
@@ -60,11 +60,13 @@ def user_login(request, user_id):
         raise ImproperlyConfigured("The CAN_LOGIN_AS setting is neither a valid module nor callable.")
 
     if user.is_superuser:
-        messages.error(request, _("You cannot log in as superusers."))
+        messages.error(request, _("You cannot log in as superusers."),
+                       extra_tags=la_settings.MESSAGE_EXTRA_TAGS)
         return redirect(request.META.get("HTTP_REFERER", "/"))
 
     if not can_login_as(request, user):
-        messages.error(request, _("You do not have permission to do that."))
+        messages.error(request, _("You do not have permission to do that."),
+                       extra_tags=la_settings.MESSAGE_EXTRA_TAGS)
         return redirect(request.META.get("HTTP_REFERER", "/"))
 
     login_as(user, request)


### PR DESCRIPTION
This PR allows:
- To set [extra tags to messages](https://docs.djangoproject.com/en/1.10/ref/contrib/messages/#adding-extra-message-tags) by defining `LOGINAS_MESSAGE_EXTRA_TAGS` in settings file.
- Inconsistent settings var naming convention, `MESSAGE_LOGIN_REVERT` changed to `LOGINAS_MESSAGE_LOGIN_REVERT`
- `signer.unsign` pass total seconds to `max_age` instead of `timedelta` for compatibility `1.7.9 <= Django < 1.8`. This brings no harm as `signer.unsign` automatically converts `timedelta` to use `.total_seconds()` in newer versions anyway.

Thanks!