### PR TITLE
Do not update user.last_login, overridable via LOGINAS_UPDATE_LAST_LOGIN

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,15 @@ from django.core.urlresolvers import reverse_lazy
 LOGOUT_URL = reverse_lazy('loginas-logout')
 ```
 
+By default, clicking "Login as user" will not update `user.last_login`.
+You can override this behavior like so:
+
+```
+# settings.py
+
+LOGINAS_UPDATE_LAST_LOGIN = True
+```
+
 Note that django-loginas won't let you log in as other superusers, to prevent
 privilege escalation from staff users to superusers. If you want to log in as
 a superuser, first demote them to a non-superuser, and then log in.

--- a/loginas/settings.py
+++ b/loginas/settings.py
@@ -20,3 +20,5 @@ MESSAGE_LOGIN_REVERT = getattr(
     "MESSAGE_LOGIN_REVERT",
     _("You are now logged back in as {username}")
 )
+
+UPDATE_LAST_LOGIN = getattr(settings, 'LOGINAS_UPDATE_LAST_LOGIN', False)

--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -2,6 +2,8 @@ import logging
 
 from django.conf import settings as django_settings
 from django.contrib.auth import get_user_model, load_backend, login, logout
+from django.contrib.auth.models import update_last_login
+from django.contrib.auth.signals import user_logged_in
 from django.contrib import messages
 from django.core.signing import TimestampSigner, SignatureExpired
 from datetime import timedelta
@@ -31,7 +33,17 @@ def login_as(user, request, store_original_user=True):
 
     # Log the user in.
     if hasattr(user, 'backend'):
+        signal_was_connected = False
+        if not la_settings.UPDATE_LAST_LOGIN:
+            # Prevent update of user last_login
+            signal_was_connected = user_logged_in.disconnect(update_last_login)
+
+        # Actually log user in
         login(request, user)
+
+        # Restore signal if needed
+        if signal_was_connected:
+            user_logged_in.connect(update_last_login)
     else:
         return
 

--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -38,12 +38,13 @@ def login_as(user, request, store_original_user=True):
             # Prevent update of user last_login
             signal_was_connected = user_logged_in.disconnect(update_last_login)
 
-        # Actually log user in
-        login(request, user)
-
-        # Restore signal if needed
-        if signal_was_connected:
-            user_logged_in.connect(update_last_login)
+        try:
+            # Actually log user in
+            login(request, user)
+        finally:
+            # Restore signal if needed
+            if signal_was_connected:
+                user_logged_in.connect(update_last_login)
     else:
         return
 


### PR DESCRIPTION
Prevent `user.last_login` being updated when superuser delegate access to normal users accounts.
This behaviour is by default turned on which is overridable via setting var:

```
# settings.py
LOGINAS_UPDATE_LAST_LOGIN=True
```

Inspired by [django-hijack](https://github.com/arteria/django-hijack/blob/master/hijack/helpers.py#L106)