### PR TITLE
Use tox in Travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,4 @@ env:
   - TOX_ENV=django19-py27
   - TOX_ENV=django18-py35
   - TOX_ENV=django18-py34
-  - TOX_ENV=django18-py33
-  - TOX_ENV=django18-py32
   - TOX_ENV=django18-py27

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,22 @@
 language: python
 python:
-  - 2.7
-  - 3.4
-install: "pip install Django==$DJANGO_VERSION"
-script: loginas/tests/manage.py test --verbosity=2 tests
+  - 3.6
+cache: pip
+install: travis_retry pip install "virtualenv<14.0.0" tox codecov
+script: tox -e $TOX_ENV
 env:
-  - DJANGO_VERSION=1.8
-  - DJANGO_VERSION=1.9
+  - TOX_ENV=django111-py36
+  - TOX_ENV=django111-py35
+  - TOX_ENV=django111-py34
+  - TOX_ENV=django111-py27
+  - TOX_ENV=django110-py35
+  - TOX_ENV=django110-py34
+  - TOX_ENV=django110-py27
+  - TOX_ENV=django19-py35
+  - TOX_ENV=django19-py34
+  - TOX_ENV=django19-py27
+  - TOX_ENV=django18-py35
+  - TOX_ENV=django18-py34
+  - TOX_ENV=django18-py33
+  - TOX_ENV=django18-py32
+  - TOX_ENV=django18-py27

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,15 @@
 [tox]
-envlist={py27,py34}-django{18,19}
+envlist={py27,py34,py35,py36}-django{18,19,110}
 
 [testenv]
 basepython=
     py27: python2.7
     py34: python3.4
+    py35: python3.5
+    py36: python3.6
 deps=
     django18: django>=1.8.0,<1.9
     django19: django>=1.9.0,<1.10
+    django110: django>=1.10.0,<1.11
+    django111: django==1.11b1
 commands=python loginas/tests/manage.py test tests --verbosity=2


### PR DESCRIPTION
Add Django 1.10 and 1.11b1 and Python 3.5 and 3.6 support.

3.6 is only available from Django 1.11 afaik.

Fixes #54