### PR TITLE
Customize login switch message username through settings.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,16 @@ You can override this behavior like so:
 LOGINAS_UPDATE_LAST_LOGIN = True
 ```
 
+By default, the login switch message will use the `User` model's
+`USERNAME_FIELD`. You can override this behavior by passing in a different
+field name:
+
+```python
+# settings.py
+
+LOGINAS_USERNAME_FIELD = 'email'
+```
+
 Note that django-loginas won't let you log in as other superusers, to prevent
 privilege escalation from staff users to superusers. If you want to log in as
 a superuser, first demote them to a non-superuser, and then log in.

--- a/loginas/settings.py
+++ b/loginas/settings.py
@@ -1,4 +1,5 @@
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.utils.translation import ugettext_lazy as _
 
 USER_SESSION_FLAG = getattr(settings, "LOGINAS_FROM_USER_SESSION_FLAG", "loginas_from_user")
@@ -10,6 +11,8 @@ CAN_LOGIN_AS = getattr(settings, "CAN_LOGIN_AS", lambda r, y: r.user.is_superuse
 LOGIN_REDIRECT = getattr(settings, "LOGINAS_REDIRECT_URL", settings.LOGIN_REDIRECT_URL)
 
 LOGOUT_REDIRECT = getattr(settings, "LOGINAS_LOGOUT_REDIRECT_URL", settings.LOGIN_REDIRECT_URL)
+
+USERNAME_FIELD = getattr(settings, "LOGINAS_USERNAME_FIELD", get_user_model().USERNAME_FIELD)
 
 MESSAGE_LOGIN_SWITCH = getattr(
     settings,

--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -13,7 +13,7 @@ from . import settings as la_settings
 
 signer = TimestampSigner()
 logger = logging.getLogger(__name__)
-username_field = get_user_model().USERNAME_FIELD
+username_field = la_settings.USERNAME_FIELD
 
 
 def login_as(user, request, store_original_user=True):


### PR DESCRIPTION
Adds support for customizing the column used to display the username in
the login switch message. If left undefined, the username defaults to
the User model's `USERNAME_FIELD`.

This feature is helpful in cases where the default Django user model is used but
another field (such as email) is preferred in the app. 

* Add `USERNAME_FIELD` to `settings.py`

* Update `utils.py` to use `USERNAME_FIELD` from loginas settings

* Update `assertLoginSuccess` to use `USERNAME_FIELD` from loginas
settings

* Add test to check that using a custom username field works