### PR TITLE
PermissionDenied support for `can_login_as`

### DIFF
--- a/loginas/tests/settings.py
+++ b/loginas/tests/settings.py
@@ -9,6 +9,7 @@ INSTALLED_APPS = (
     "django.contrib.sessions",
     "django.contrib.auth",
     "django.contrib.admin",
+    "django.contrib.messages",
     "loginas",
     "loginas.tests",
 )


### PR DESCRIPTION
This PR allows to customize error message in admin view when you want to specify why it's not permitted to log in as a target user.