### PR TITLE
Check that request.session exists when testing for impersonation

### DIFF
--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -122,4 +122,4 @@ def is_impersonated_session(request):
     """
     Checks if the session in the request is impersonated or not
     """
-    return la_settings.USER_SESSION_FLAG in request.session
+    return hasattr(request, 'session') and la_settings.USER_SESSION_FLAG in request.session


### PR DESCRIPTION
I ran into an issue with loginas where the context processor for adding the `is_impersonated` variable to templates can conflict with installed middleware.

This seems to be caused by the `request` not having a `session` property in all cases after passing through all of the middleware, and before passing through all of the context processors.

The fix here is to simply check if the `session` property exists, otherwise the is_impersonated_session method will always return False.