### PR TITLE
Replacing deprecated `ugettext_lazy` with `gettext_lazy`

### DIFF
--- a/loginas/settings.py
+++ b/loginas/settings.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.contrib.auth import get_user_model
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 USER_SESSION_FLAG = getattr(settings, "LOGINAS_FROM_USER_SESSION_FLAG", "loginas_from_user")
 

--- a/loginas/views.py
+++ b/loginas/views.py
@@ -2,7 +2,7 @@ from django.contrib import messages
 from django.contrib.admin.utils import unquote
 from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.shortcuts import redirect
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.views.decorators.csrf import csrf_protect
 from django.views.decorators.http import require_POST
 


### PR DESCRIPTION
Since support for Python 2 was dropped in 0.3.7, and Django recently deprecated the `ugettext_` functions (https://docs.djangoproject.com/en/3.0/releases/3.0/#id3), I just replaced all occurrences of `ugettext_` with the their `gettext_` equivalents.