### PR TITLE
Modernize Django URL's

### DIFF
--- a/loginas/urls.py
+++ b/loginas/urls.py
@@ -1,7 +1,7 @@
-from django.conf.urls import url
+from django.urls import path
 from loginas.views import user_login, user_logout
 
 urlpatterns = [
-    url(r"^login/user/(?P<user_id>.+)/$", user_login, name="loginas-user-login"),
-    url(r"^logout/$", user_logout, name="loginas-logout"),
+    path("login/user/<str:user_id>/", user_login, name="loginas-user-login"),
+    path("logout/", user_logout, name="loginas-logout"),
 ]


### PR DESCRIPTION
Fixes this warning:

```
.../python3.9/site-packages/loginas/urls.py:6: RemovedInDjango40Warning: django.conf.urls.url() is deprecated in favor of django.urls.re_path().
    url(r"^logout/$", user_logout, name="loginas-logout"),
```

And uses the new path syntax added in Django 2.0