### PR TITLE
Updates for Python 3.10 and Django 4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,8 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        django-version: ["2.2", "3.1", "3.2"]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        django-version: ["2.2", "3.2", "4.0"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        exclude:
+          - python-version: "3.7"
+            django-version: "4.0"
     steps:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,8 +4,8 @@ repos:
   hooks:
   - id: black
     args: [--line-length=120]
-- repo: git://github.com/doublify/pre-commit-isort
-  rev: v4.3.0
+- repo: https://github.com/PyCQA/isort
+  rev: '5.10.1'
   hooks:
   -   id: isort
 - repo: https://gitlab.com/pycqa/flake8

--- a/loginas/tests/tests.py
+++ b/loginas/tests/tests.py
@@ -12,6 +12,7 @@ from django.core.exceptions import ImproperlyConfigured, PermissionDenied
 from django.test import Client, TestCase
 from django.test.utils import override_settings as override_settings_orig
 from django.utils import timezone
+
 from loginas import settings as la_settings
 
 try:

--- a/loginas/tests/urls.py
+++ b/loginas/tests/urls.py
@@ -1,8 +1,9 @@
-from django.conf.urls import include, url
+from django.urls import include, path
+
 from loginas.tests import views
 
 urlpatterns = [
-    url(r"^$", views.index, name="index"),
-    url(r"^current_user/$", views.current_user, name="current_user"),
-    url(r"^", include("loginas.urls")),
+    path("", views.index, name="index"),
+    path("current_user/", views.current_user, name="current_user"),
+    path("", include("loginas.urls")),
 ]

--- a/loginas/urls.py
+++ b/loginas/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+
 from loginas.views import user_login, user_logout
 
 urlpatterns = [

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python
 
-import sys
-
 from loginas import __version__
-
-assert sys.version >= "3.4", "Requires Python v3.4 or above."
 
 try:
     from setuptools import setup
@@ -26,5 +22,4 @@ setup(
     include_package_data=True,
     packages=["loginas"],
     package_dir={"loginas": "loginas"},
-    python_requires=">3.3",
 )


### PR DESCRIPTION
I updated the CI for Python 3.10 and Django 4.0, and removed now-unsupported versions (Python 3.6 and Django 3.1).

This required some other minor changes.