### PR TITLE
Add support for specifying login reason

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,15 @@ This example uses a symlink:
 ln -s <path_to_site_packages>/loginas/static/loginas static/loginas
 ```
 
+By default, specifying a reason is not required.
+You can override this behavior like so:
+
+```python
+# settings.py
+
+LOGINAS_LOGIN_REASON_REQUIRED = True
+```
+
 Other implementation suggestions
 --------------------------------
 

--- a/loginas/settings.py
+++ b/loginas/settings.py
@@ -41,3 +41,5 @@ UPDATE_LAST_LOGIN = getattr(settings, "LOGINAS_UPDATE_LAST_LOGIN", False)
 MESSAGE_EXTRA_TAGS = getattr(settings, "LOGINAS_MESSAGE_EXTRA_TAGS", "")
 
 CSP_FRIENDLY = getattr(settings, "LOGINAS_CSP_FRIENDLY", False)
+
+LOGIN_REASON_REQUIRED = getattr(settings, "LOGINAS_LOGIN_REASON_REQUIRED", False)

--- a/loginas/static/loginas/loginas.js
+++ b/loginas/static/loginas/loginas.js
@@ -2,9 +2,55 @@
 
 django.jQuery(document).ready(function()
 {
-   django.jQuery('#loginas-link').click(function()
-   {
-       django.jQuery('#loginas-form').submit();
-       return false;
-   });
+    var $ = django.jQuery;
+    var reasonRequired = $('#loginas-modal').data('reason-required') === true;
+
+    $('#loginas-link').click(function()
+    {
+        $('#loginas-modal').show();
+        $('#loginas-reason').val('').removeClass('loginas-invalid').focus();
+        $('#loginas-error').hide();
+        return false;
+    });
+
+    $('#loginas-cancel, #loginas-modal-backdrop').click(function()
+    {
+        $('#loginas-modal').hide();
+    });
+
+    $('#loginas-confirm').click(function()
+    {
+        var reason = $('#loginas-reason').val().trim();
+        if (reasonRequired && !reason) {
+            $('#loginas-reason').addClass('loginas-invalid');
+            $('#loginas-error').show();
+            $('#loginas-reason').focus();
+            return;
+        }
+        $('#loginas-reason-input').val(reason);
+        $('#loginas-form').submit();
+    });
+
+    $('#loginas-reason').on('input', function()
+    {
+        if ($(this).val().trim()) {
+            $(this).removeClass('loginas-invalid');
+            $('#loginas-error').hide();
+        }
+    });
+
+    $('#loginas-reason').keydown(function(e)
+    {
+        if (e.key === 'Escape') {
+            $('#loginas-modal').hide();
+        }
+    });
+
+    $('#loginas-modal-dialog').keydown(function(e)
+    {
+        if (e.key === 'Enter' && !e.shiftKey) {
+            e.preventDefault();
+            $('#loginas-confirm').click();
+        }
+    });
 });

--- a/loginas/templates/loginas/change_form.html
+++ b/loginas/templates/loginas/change_form.html
@@ -12,6 +12,9 @@
     {{ block.super }}
     <form method="post" id="loginas-form" action="{% url 'loginas-user-login' object_id %}" style="display: none">
         {% csrf_token %}
+        <input type="hidden" name="reason" id="loginas-reason-input" value="">
     </form>
+
+    {% modal %}
     {% javascript %}
 {% endblock %}

--- a/loginas/templates/loginas/javascript.html
+++ b/loginas/templates/loginas/javascript.html
@@ -1,14 +1,55 @@
 {% load static %}
 
 {% if csp_aware %}
-	<script type="text/javascript" src="{% static 'loginas/loginas.js' %}"></script>
+    <script type="text/javascript" src="{% static 'loginas/loginas.js' %}"></script>
 {% else %}
     <script>
     django.jQuery(function() {
-          django.jQuery('#loginas-link').click(function() {
-            django.jQuery('#loginas-form').submit();
+        var $ = django.jQuery;
+        var reasonRequired = {{ reason_required|yesno:"true,false" }};
+
+        $('#loginas-link').click(function() {
+            $('#loginas-modal').show();
+            $('#loginas-reason').val('').removeClass('loginas-invalid').focus();
+            $('#loginas-error').hide();
             return false;
-          });
         });
+
+        $('#loginas-cancel, #loginas-modal-backdrop').click(function() {
+            $('#loginas-modal').hide();
+        });
+
+        $('#loginas-confirm').click(function() {
+            var reason = $('#loginas-reason').val().trim();
+            if (reasonRequired && !reason) {
+                $('#loginas-reason').addClass('loginas-invalid');
+                $('#loginas-error').show();
+                $('#loginas-reason').focus();
+                return;
+            }
+            $('#loginas-reason-input').val(reason);
+            $('#loginas-form').submit();
+        });
+
+        $('#loginas-reason').on('input', function() {
+            if ($(this).val().trim()) {
+                $(this).removeClass('loginas-invalid');
+                $('#loginas-error').hide();
+            }
+        });
+
+        $('#loginas-reason').keydown(function(e) {
+            if (e.key === 'Escape') {
+                $('#loginas-modal').hide();
+            }
+        });
+
+        $('#loginas-modal-dialog').keydown(function(e) {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                $('#loginas-confirm').click();
+            }
+        });
+    });
     </script>
 {% endif %}

--- a/loginas/templates/loginas/modal.html
+++ b/loginas/templates/loginas/modal.html
@@ -1,0 +1,94 @@
+{% load i18n %}
+
+<div id="loginas-modal" style="display: none;" data-reason-required="{{ reason_required|yesno:"true,false" }}">
+    <div id="loginas-modal-backdrop"></div>
+    <div id="loginas-modal-dialog">
+        <h2>{% trans "Log in as user" %}</h2>
+        <p>{% if reason_required %}{% trans "Please provide a reason for this action:" %}{% else %}{% trans "Please provide a reason for this action (optional):" %}{% endif %}</p>
+        <textarea id="loginas-reason" rows="3" placeholder="{% trans "e.g., Investigating support ticket #1234" %}"{% if reason_required %} required{% endif %}></textarea>
+        <p id="loginas-error" style="display: none; color: var(--error-fg, #ba2121); margin: 10px 0 0 0;">{% trans "A reason is required." %}</p>
+        <div id="loginas-modal-buttons">
+            <button type="button" id="loginas-cancel" class="button">{% trans "Cancel" %}</button>
+            <button type="button" id="loginas-confirm" class="button default">{% trans "Log in as user" %}</button>
+        </div>
+    </div>
+</div>
+
+<style>
+    #loginas-modal-backdrop {
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        background: rgba(0, 0, 0, 0.5);
+        z-index: 9998;
+    }
+    #loginas-modal-dialog {
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        background: var(--body-bg, #fff);
+        padding: 20px 25px;
+        border-radius: 4px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
+        z-index: 9999;
+        min-width: 400px;
+        max-width: 90%;
+    }
+    #loginas-modal-dialog h2 {
+        margin: 0 0 15px 0;
+        font-size: 18px;
+        color: var(--body-fg, #333);
+    }
+    #loginas-modal-dialog p {
+        margin: 0 0 10px 0;
+        color: var(--body-quiet-color, #666);
+    }
+    #loginas-reason {
+        width: 100%;
+        box-sizing: border-box;
+        padding: 8px 10px;
+        border: 1px solid var(--border-color, #ccc);
+        border-radius: 4px;
+        font-size: 14px;
+        font-family: inherit;
+        resize: vertical;
+        background: var(--body-bg, #fff);
+        color: var(--body-fg, #333);
+    }
+    #loginas-reason:focus {
+        outline: none;
+        border-color: var(--primary, #417690);
+    }
+    #loginas-reason.loginas-invalid {
+        border-color: var(--error-fg, #ba2121);
+    }
+    #loginas-modal-buttons {
+        margin-top: 15px;
+        text-align: right;
+    }
+    #loginas-modal-buttons .button {
+        padding: 8px 16px;
+        margin-left: 10px;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        font-size: 14px;
+    }
+    #loginas-cancel {
+        background: var(--close-button-bg, #888);
+        color: #fff;
+    }
+    #loginas-cancel:hover {
+        background: var(--close-button-hover-bg, #666);
+    }
+    #loginas-confirm {
+        background: var(--primary, #417690);
+        color: #fff;
+    }
+    #loginas-confirm:hover {
+        background: var(--primary-fg, #205067);
+    }
+</style>

--- a/loginas/templatetags/loginas_javascript.py
+++ b/loginas/templatetags/loginas_javascript.py
@@ -7,10 +7,16 @@ harder deployment)
 from django import template
 
 from loginas.settings import CSP_FRIENDLY
+from loginas.settings import LOGIN_REASON_REQUIRED
 
 register = template.Library()
 
 
+@register.inclusion_tag(filename="loginas/modal.html")
+def modal():
+    return {"reason_required": LOGIN_REASON_REQUIRED}
+
+
 @register.inclusion_tag(filename="loginas/javascript.html")
 def javascript():
-    return {"csp_aware": CSP_FRIENDLY}
+    return {"csp_aware": CSP_FRIENDLY, "reason_required": LOGIN_REASON_REQUIRED}

--- a/loginas/utils.py
+++ b/loginas/utils.py
@@ -42,7 +42,7 @@ def no_update_last_login():
         user_logged_in.connect(**kw_id)
 
 
-def login_as(user, request, store_original_user=True):
+def login_as(user, request, store_original_user=True, reason=""):
     """
     Utility function for forcing a login as specific user -- be careful about
     calling this carelessly :)
@@ -68,6 +68,8 @@ def login_as(user, request, store_original_user=True):
     # Add admin audit log entry
     if original_user_pk:
         change_message = "User {0} logged in as {1}.".format(request.user, user)
+        if reason:
+            change_message += " Reason: {0}".format(reason)
         try:
             LogEntry.objects.log_actions(
                 user_id=original_user_pk,

--- a/loginas/views.py
+++ b/loginas/views.py
@@ -79,8 +79,19 @@ def user_login(request, user_id):
         )
         return redirect(request.META.get("HTTP_REFERER", "/"))
 
+    reason = request.POST.get("reason", "").strip()
+
+    if la_settings.LOGIN_REASON_REQUIRED and not reason:
+        messages.error(
+            request,
+            _("A reason is required when logging in as another user."),
+            extra_tags=la_settings.MESSAGE_EXTRA_TAGS,
+            fail_silently=True,
+        )
+        return redirect(request.META.get("HTTP_REFERER", "/"))
+
     try:
-        login_as(user, request)
+        login_as(user, request, reason=reason)
     except ImproperlyConfigured as e:
         messages.error(
             request,


### PR DESCRIPTION
This PR adds support for specifying a reason when performing a login. The reason is optional by default and is logged as part of the `change_message`. Setting `LOGINAS_LOGIN_REASON_REQUIRED = True` makes specifying a reason required.

I've included fairly comprehensive tests for this new functionality.

Closes #103.

<img width="1444" height="995" alt="Screenshot 2025-12-13 at 12 17 06" src="https://github.com/user-attachments/assets/e079d4b3-e6c5-4a0f-bf83-4a50734ae52f" />
